### PR TITLE
Add "consumer-mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Gdbmish::Dump.ascii(data, file: "my.db")
 
 # Provide an original filename and file permissions
 Gdbmish::Dump.ascii(data, file: "my.db", uid: "1000", gid: "1000", mode: 0o600)
+
+# Iterate over a data source and push onto an IO
+fileoptions = {file: "my.db", uid: "1000", user: "ziggy", gid: "1000", group: "staff", mode: 0o600}
+File.open("my.dump", "w") do |file|
+  Gdbmish::Dump::Ascii.new(**fileoptions).dump(io) do |appender|
+    MyDataSource.each do |key, value|
+      appender << {key.to_s, value.to_s}
+    end
+  end
+end
 ```
 
 ## Development
@@ -59,8 +69,6 @@ TODO: Write development instructions here
 ## Limitations
 
 * Currently only supports the ASCII format and not the Binary format
-* Currently requires a `Hash` or `NamedTuple` with `String` keys and values
-  + it would be nice to provide a "consumer" style API for dumping larger data sets
 * Currently only supports creating a dump
   + it would be nice to also read dumps 
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,16 @@
 require "spec"
 require "../src/gdbmish"
+
+DATA = {
+  föö:  "bää\n🤦‍♂️",
+  foo2: "bar2",
+  foo:  ("bar-"*128),
+}
+def data
+  DATA
+end
+
+DUMPED_WITHOUT_HEADER = File.read("spec/fixtures/test.dump").split("# End of header\n")[1]
+def dumped_without_header
+  DUMPED_WITHOUT_HEADER
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,11 +6,13 @@ DATA = {
   foo2: "bar2",
   foo:  ("bar-"*128),
 }
+
 def data
   DATA
 end
 
 DUMPED_WITHOUT_HEADER = File.read("spec/fixtures/test.dump").split("# End of header\n")[1]
+
 def dumped_without_header
   DUMPED_WITHOUT_HEADER
 end

--- a/src/gdbmish/dump.cr
+++ b/src/gdbmish/dump.cr
@@ -17,7 +17,7 @@ module Gdbmish
         getter count
 
         def initialize(@io : IO)
-          @count = 0
+          @count = 0_u64
         end
 
         # Push a `{"key", "value"}` `Tuple` onto the dump
@@ -130,7 +130,7 @@ module Gdbmish
         io.puts("# End of header")
       end
 
-      private def dump_footer!(io : IO, count : Int64) : Nil
+      private def dump_footer!(io : IO, count : UInt64) : Nil
         io.printf("#:count=%d\n", count)
         io.puts("# End of data")
       end

--- a/src/gdbmish/dump.cr
+++ b/src/gdbmish/dump.cr
@@ -1,87 +1,201 @@
 require "base64"
 
 module Gdbmish
+  # Wrapper for different dump formats, providing various shortcut methods.
+  # Currently, there is only `Ascii` mode.
+  #
+  # Ascii mode optionally dumps file information such as filename, owner, mode.
+  # See `Dump::Ascii.new` on how they are used.
   module Dump
-    # GDBMs does not split base64 strings at 60 encoded characters (as defined by RFC 2045).
-    # See [gdbmdefs.h](https://git.gnu.org.ua/gdbm.git/tree/src/gdbmdefs.h)
-    GDBM_MAX_DUMP_LINE_LEN = 76
+    struct Ascii
+      # Appends and counts `#push`ed data as ASCII dump format onto `@io`.
+      #
+      # Users should not use this class stand-alone, as it only represents the
+      # data part of an dump, without header and footer. An instance of it gets
+      # yielded when using `Ascii#dump(io) { |appender| }`
+      class Appender
+        getter count
 
-    # Dump the given data in standard ASCII format into a provided `IO`.
-    #
-    # Dumping file information is optional.
-    # * *uid*, *user*, *gid*, *group* and *mode* will only be used when *file* is given
-    # * *user* will only be used when *uid* is given
-    # * *group* will only be used when *gid* is given
-    def self.ascii(
-      data : (Hash | NamedTuple),
-      io : (IO),
-      file : String? = nil,
-      uid : String? = nil,
-      user : String? = nil,
-      gid : String? = nil,
-      group : String? = nil,
-      mode : Int32? = nil
-    )
-      io.printf("# GDBM dump file created by GDBMish version %s on %s\n", Gdbmish::VERSION, Time.local.to_rfc2822)
-      io.puts("#:version=1.1")
-
-      if file
-        io.printf("#:file=%s\n", file)
-        l = [] of String
-
-        if uid
-          l << sprintf("uid=%d", uid)
-          l << sprintf("user=%s", user) if user
+        def initialize(@io : IO)
+          @count = 0
         end
 
-        if gid
-          l << sprintf("gid=%d", gid)
-          l << sprintf("group=%s", group) if group
+        # Push a `{"key", "value"}` `Tuple` onto the dump
+        def push(kv : {String, String}) : Nil
+          @count += 1
+          kv.each { |d| @io << dump_datum(d) }
         end
 
-        l << sprintf("mode=%03o", mode & 0o777) if mode
-
-        unless l.empty?
-          io << "#:"
-          io.puts(l.join(","))
+        # Alias for `push`
+        def <<(kv : {String, String}) : Nil
+          push(kv)
         end
-      end
 
-      io.puts("#:format=standard")
-      io.puts("# End of header")
-
-      data.each do |k, v|
-        io << ascii_dump_datum(k.to_s)
-        io << ascii_dump_datum(v.to_s)
-      end
-
-      io.printf("#:count=%d\n", data.size)
-      io.puts("# End of data")
-    end
-
-    # Like `ascii` but builds a new `String`
-    def self.ascii(data : (Hash | NamedTuple), **options) : String
-      String.build do |str|
-        self.ascii(
-          data,
-          str,
-          **options
-        )
-      end
-    end
-
-    private def self.ascii_dump_datum(datum : String) : String
-      String.build do |str|
-        str.printf("#:len=%d\n", datum.bytesize)
-        str.puts(Base64.strict_encode(datum).try do |enc|
-          if enc.size > GDBM_MAX_DUMP_LINE_LEN
-            slices = enc.each_char.each_slice(GDBM_MAX_DUMP_LINE_LEN)
-            slices.map(&.join).join("\n")
-          else
-            enc
+        private def dump_datum(datum : String) : String
+          String.build do |str|
+            str.printf("#:len=%d\n", datum.bytesize)
+            str.puts(Base64.strict_encode(datum).try do |enc|
+              if enc.size > GDBM_MAX_DUMP_LINE_LEN
+                slices = enc.each_char.each_slice(GDBM_MAX_DUMP_LINE_LEN)
+                slices.map(&.join).join("\n")
+              else
+                enc
+              end
+            end)
           end
-        end)
+        end
       end
+
+      # GDBMs does not split base64 strings at 60 encoded characters (as defined by RFC 2045).
+      # See [gdbmdefs.h](https://git.gnu.org.ua/gdbm.git/tree/src/gdbmdefs.h)
+      GDBM_MAX_DUMP_LINE_LEN = 76
+
+      # Builds a new Ascii format dumper
+      #
+      # Dumping file information is optional.
+      # * *uid*, *user*, *gid*, *group* and *mode* will only be used when *file* is given
+      # * *user* will only be used when *uid* is given
+      # * *group* will only be used when *gid* is given
+      #
+      # Example:
+      # ```
+      # fileoptions = {file: "test.db", uid: "1000", user: "ziggy", gid: "1000", group: "staff", mode: 0o600}
+      # File.open("test.dump", "w") do |file|
+      #   Gdbmish::Dump::Ascii.new(**fileoptions).dump(io) do |appender|
+      #     MyDataSource.each do |key, value|
+      #       appender << {key.to_s, value.to_s}
+      #     end
+      #   end
+      # end
+      # ```
+      def initialize(
+        @file : String? = nil,
+        @uid : String? = nil,
+        @user : String? = nil,
+        @gid : String? = nil,
+        @group : String? = nil,
+        @mode : Int32? = nil
+      )
+      end
+
+      def dump(io : IO, & : Appender -> _) : IO
+        appender = Appender.new(io)
+
+        dump_header!(io)
+        yield appender
+        dump_footer!(io, appender.count)
+
+        return io
+      end
+
+      def dump(io : IO, data : (Hash | NamedTuple)) : IO
+        appender = Appender.new(io)
+
+        dump_header!(io)
+        data.each do |k, v|
+          appender << {k.to_s, v.to_s}
+        end
+        dump_footer!(io, appender.count)
+
+        return io
+      end
+
+      private def dump_header!(io : IO) : Nil
+        io.printf("# GDBM dump file created by GDBMish version %s on %s\n", Gdbmish::VERSION, Time.local.to_rfc2822)
+        io.puts("#:version=1.1")
+
+        if @file
+          io.printf("#:file=%s\n", @file)
+          l = [] of String
+
+          if @uid
+            l << sprintf("uid=%d", @uid)
+            l << sprintf("user=%s", @user) if @user
+          end
+
+          if @gid
+            l << sprintf("gid=%d", @gid)
+            l << sprintf("group=%s", @group) if @group
+          end
+
+          @mode.try { |mode| l << sprintf("mode=%03o", mode & 0o777) }
+
+          unless l.empty?
+            io << "#:"
+            io.puts(l.join(","))
+          end
+        end
+
+        io.puts("#:format=standard")
+        io.puts("# End of header")
+      end
+
+      private def dump_footer!(io : IO, count : Int64) : Nil
+        io.printf("#:count=%d\n", count)
+        io.puts("# End of data")
+      end
+    end
+
+    # Dump *data* as standard ASCII format into *io*.
+    #
+    # For *fileoptions* see `Dump::Ascii.new`
+    #
+    # Example:
+    # ```
+    # Gdbmish::Dump.ascii({some: "data"}, io)
+    # ```
+    def self.ascii(data : (Hash | NamedTuple), io : IO, **fileoptions) : IO
+      Ascii.new(**fileoptions).dump(io, data)
+    end
+
+    # Dump *data* as standard ASCII format into a new `String`.
+    #
+    # For *fileoptions* see `Dump::Ascii.new`
+    #
+    # Example:
+    # ```
+    # dump = Gdbmish::Dump.ascii({some: "data"})
+    # ```
+    def self.ascii(data : (Hash | NamedTuple), **fileoptions) : String
+      String.build do |io|
+        Ascii.new(**fileoptions).dump(io, data)
+      end
+    end
+
+    # Yields a `Ascii::Appender` which consumes key-value `Tuple`s.
+    # Returns a standard ASCII format as a new `String`.
+    #
+    # For *fileoptions* see `Dump::Ascii.new`
+    #
+    # Example:
+    # ```
+    # dump = Gdbmish::Dump.ascii do |appender|
+    #   MyDataSource.each do |key, value|
+    #     appender << {key.to_s, value.to_s}
+    #   end
+    # end
+    # ```
+    def self.ascii(**fileoptions, &block : Ascii::Appender -> _) : String
+      String.build do |io|
+        Ascii.new(**fileoptions).dump(io, &block)
+      end
+    end
+
+    # Yields a `Ascii::Appender` which consumes key-value `Tuple`s.
+    # Dumps a standard ASCII format into *io*.
+    #
+    # For *fileoptions* see `Dump::Ascii.new`
+    #
+    # Example:
+    # ```
+    # dump = Gdbmish::Dump.ascii(io) do |appender|
+    #   MyDataSource.each do |key, value|
+    #     appender << {key.to_s, value.to_s}
+    #   end
+    # end
+    # ```
+    def self.ascii(io : IO, **fileoptions, &block : Ascii::Appender -> _) : String
+      Ascii.new(**fileoptions).dump(io, &block)
     end
   end
 end


### PR DESCRIPTION
Allow to programmatically push key-value tuples from any source when carting an ascii dump