### PR TITLE
Add ascii dump reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal: ["1.0", "1.1", "1.2", "1.3", latest, nightly]
+        crystal: ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", latest, nightly]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -64,15 +64,31 @@ end
 
 On the target host, use a tool like `gdbm_load` to convert the dump into a db that works with that hosts gdbm.
 
+Read a GDBM Dump:
+
+```crystal
+reader = Gdbmish::Read::Ascii.new(File.open("my.dump"))
+
+# get meta data
+reader.meta.file # => "my.db"
+
+# either iterate over data:
+reader.data do |key, value|
+  puts "#{key.inspect} => #{value.inspect}"
+end
+
+# or use the Iterator to transform into Hash
+reader.data.to_h
+```
+
 ## Development
 
-TODO: Write development instructions here
+* Run specs using `crystal spec`
+* Format files using `crystal tool format`
 
 ## Limitations
 
 * Currently only supports the ASCII format and not the Binary format
-* Currently only supports creating a dump
-  + it would be nice to also read dumps 
 
 ## Contributing
 

--- a/spec/gdbmish_spec.cr
+++ b/spec/gdbmish_spec.cr
@@ -1,0 +1,5 @@
+require "./spec_helper"
+
+describe Gdbmish do
+  it { Gdbmish::VERSION.should_not be nil }
+end

--- a/spec/read_spec.cr
+++ b/spec/read_spec.cr
@@ -1,0 +1,96 @@
+require "./spec_helper"
+
+describe Gdbmish::Read::Ascii do
+  it "can read it's own dump" do
+    io = IO::Memory.new
+    dumper = Gdbmish::Dump::Ascii.new(file: "test.db", uid: "1000", user: "ziggy", gid: "1000", group: "staff", mode: 0o640)
+    dumper.dump(io) do |dump|
+      dump << {"some_key", "Some Value"}
+      dump << {"otherKey", "Other\nValue"}
+    end
+
+    io.rewind
+    file = Gdbmish::Read::Ascii.new(io, load_meta: :count)
+
+    file.data.to_h.should eq({
+      "some_key" => "Some Value",
+      "otherKey" => "Other\nValue",
+    })
+
+    meta = file.meta.not_nil!
+    meta.file.should eq "test.db"
+    meta.uid.should eq "1000"
+    meta.user.should eq "ziggy"
+    meta.gid.should eq "1000"
+    meta.group.should eq "staff"
+    meta.mode.should eq 0o640
+    meta.count.should eq(2)
+  end
+
+  it "load_meta: false skips loading meta" do
+    f = Gdbmish::Read::Ascii.new(dumped_file, load_meta: false)
+    f.meta.should be_nil
+    f.data.to_h.should eq(data_hash)
+  end
+
+  it "load_meta: true skips loading count in meta" do
+    f = Gdbmish::Read::Ascii.new(dumped_file, load_meta: true)
+    f.meta.should be_a(Gdbmish::Read::AsciiMetaData)
+    f.meta.not_nil!.count.should be_nil
+    f.data.to_h.should eq(data_hash)
+  end
+
+  it "load_meta: :count loads count in meta" do
+    f = Gdbmish::Read::Ascii.new(dumped_file, load_meta: :count)
+    f.meta.should be_a(Gdbmish::Read::AsciiMetaData)
+    f.meta.not_nil!.count.should eq(3)
+    f.data.to_h.should eq(data_hash)
+  end
+end
+
+describe Gdbmish::Read::AsciiMetaData do
+  describe ".parse" do
+    it "Reads meta data_hash, skiping count" do
+      data_hash = Gdbmish::Read::AsciiMetaData.parse(dumped_file)
+      data_hash.count.should be_nil
+      data_hash.file.should eq "test.db"
+      data_hash.gid.should eq "20"
+      data_hash.group.should eq "staff"
+      data_hash.mode.should eq 0o600
+      data_hash.uid.should eq "501"
+      data_hash.user.should eq "robertschulze"
+      data_hash.version.should eq "1.1"
+    end
+  end
+
+  describe ".parse ignore_count: false" do
+    it "Reads meta data_hash, including count" do
+      data_hash = Gdbmish::Read::AsciiMetaData.parse(dumped_file, ignore_count: false)
+      data_hash.count.should eq 3
+      data_hash.file.should eq "test.db"
+      data_hash.gid.should eq "20"
+      data_hash.group.should eq "staff"
+      data_hash.mode.should eq 0o600
+      data_hash.uid.should eq "501"
+      data_hash.user.should eq "robertschulze"
+      data_hash.version.should eq "1.1"
+    end
+  end
+end
+
+describe Gdbmish::Read::AsciiLineIterator do
+  it "iterates over encoded keys and values" do
+    read_data = Gdbmish::Read::AsciiLineIterator.new(dumped_file).to_a
+    data_keys_values_encoded = data_hash.to_a.flat_map &.to_a.map { |d| Base64.strict_encode(d) }
+
+    read_data.should eq(data_keys_values_encoded)
+  end
+end
+
+describe Gdbmish::Read::AsciiDataIterator do
+  it "iterates over decoded keys and values" do
+    read_data = Gdbmish::Read::AsciiDataIterator.new(dumped_file).to_h
+
+    read_data.should eq(data_hash)
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,18 +1,34 @@
 require "spec"
 require "../src/gdbmish"
 
-DATA = {
+DATA_HASH = {
+  "föö"  => "bää\n🤦‍♂️",
+  "foo2" => "bar2",
+  "foo"  => ("bar-"*128),
+}
+
+DATA_TUPLE = {
   föö:  "bää\n🤦‍♂️",
   foo2: "bar2",
   foo:  ("bar-"*128),
 }
 
-def data
-  DATA
+DUMPED_FILE = "spec/fixtures/test.dump"
+
+DUMPED_FULL = File.read(DUMPED_FILE)
+
+def data_hash
+  DATA_HASH
 end
 
-DUMPED_WITHOUT_HEADER = File.read("spec/fixtures/test.dump").split("# End of header\n")[1]
+def data_tuple
+  DATA_TUPLE
+end
+
+def dumped_file
+  File.open(DUMPED_FILE)
+end
 
 def dumped_without_header
-  DUMPED_WITHOUT_HEADER
+  DUMPED_FULL.split("# End of header\n")[1]
 end

--- a/src/gdbmish/dump.cr
+++ b/src/gdbmish/dump.cr
@@ -61,7 +61,7 @@ module Gdbmish
       # ```
       # fileoptions = {file: "test.db", uid: "1000", user: "ziggy", gid: "1000", group: "staff", mode: 0o600}
       # File.open("test.dump", "w") do |file|
-      #   Gdbmish::Dump::Ascii.new(**fileoptions).dump(io) do |appender|
+      #   Gdbmish::Dump::Ascii.new(**fileoptions).dump(file) do |appender|
       #     MyDataSource.each do |key, value|
       #       appender << {key.to_s, value.to_s}
       #     end
@@ -162,7 +162,7 @@ module Gdbmish
       end
     end
 
-    # Yields a `Ascii::Appender` which consumes key-value `Tuple`s.
+    # Yields a `Ascii::Appender` which consumes key/value `Tuple`s.
     # Returns a standard ASCII format as a new `String`.
     #
     # For *fileoptions* see `Dump::Ascii.new`
@@ -181,7 +181,7 @@ module Gdbmish
       end
     end
 
-    # Yields a `Ascii::Appender` which consumes key-value `Tuple`s.
+    # Yields a `Ascii::Appender` which consumes key/value `Tuple`s.
     # Dumps a standard ASCII format into *io*.
     #
     # For *fileoptions* see `Dump::Ascii.new`

--- a/src/gdbmish/read.cr
+++ b/src/gdbmish/read.cr
@@ -1,0 +1,223 @@
+require "base64"
+
+module Gdbmish
+  # Wrapper for reading GDBM dump files. Currently, only Ascii (aka standard) format is supported.
+  #
+  # See `Read::Ascii` for the main high level interface.
+  module Read
+    # Main abstraction to read an GDBM Ascii dump file (aka "standard format")
+    #
+    # Example:
+    # ```
+    # io = File.open("path/to/file.dump")
+    # file = Gdbmish::Read::Ascii.new(io)
+    #
+    # file.data do |key, value|
+    #   puts "#{key.inspect} => #{value.inspect}"
+    # end
+    # pp file.meta
+    #
+    # # Note: your `io`'s file pointer posistion has changed.
+    # io.pos # => 317
+    # ```
+    #
+    # Produces:
+    #
+    # ```text
+    # "some_key" => "Some Value"
+    # "otherKey" => "Other\nValue"
+    # Gdbmish::Read::AsciiMetaData(
+    #  @count=nil,
+    #  @file="test.db",
+    #  @gid="1000",
+    #  @group="staff",
+    #  @mode=384,
+    #  @uid="1000",
+    #  @user="ziggy",
+    #  @version="1.1")
+    # ```
+    struct Ascii
+      @meta : AsciiMetaData?
+
+      # Create a new Ascii reader.
+      #
+      # - *io* is assumed to point to the beginning of the GDBM dump.
+      # - *load_meta* can take three values:
+      #   + `true`: (default) load meta data, but skip `count` for preformance reasons.
+      #   + `false`: skip loading meta data.
+      #   + `:count`: load meta data, including `count`.
+      def initialize(@io : IO, @load_meta : Bool | Symbol = true)
+      end
+
+      # Returns an Iterator over key/value pairs.
+      #
+      # Depending on the size of the dataset, you might want to read everything into an Array or Hash:
+      # ```
+      # Ascii.new(io).data.to_a # => [{"some_key", "Some Value"}, {"otherKey", "Other\nValue"}]
+      # Ascii.new(io).data.to_h # => {"some_key" => "Some Value", "otherKey" => "Other\nValue"}
+      # ```
+      def data : AsciiDataIterator
+        load_meta
+        AsciiDataIterator.new(@io)
+      end
+
+      # Shortcut for `data.each { |key, value| }`
+      def data(&block : (String, String?) -> _) : Nil
+        data.each(&block)
+      end
+
+      # Parses for meta data, depending on the *load_meta* value in `new`
+      def meta : AsciiMetaData?
+        load_meta
+      end
+
+      private def load_meta : AsciiMetaData?
+        return unless @load_meta
+
+        @meta ||= AsciiMetaData.parse(@io, ignore_count: @load_meta != :count)
+      end
+    end
+
+    # Header and footer meta data from a GDBM Ascii dump file.
+    struct AsciiMetaData
+      getter version : String?
+      getter file : String?
+      getter uid : String?
+      getter user : String?
+      getter gid : String?
+      getter group : String?
+      # octal unix file mode
+      getter mode : Int32?
+      getter count : UInt64?
+
+      def initialize(@version = nil, @file = nil, @uid = nil, @user = nil, @gid = nil, @group = nil, @mode = nil, @count = nil)
+      end
+
+      # Parse given IO for meta data.
+      # Reads from +io+ until a `"# End of header"` line is found (enhancing its `pos`).
+      # By default, ignores reading the `count` (indecating the amount of datasets in the file) because it is written at the end of the file.
+      def self.parse(io : IO, ignore_count = true)
+        version : String? = nil
+        file : String? = nil
+        uid : String? = nil
+        user : String? = nil
+        gid : String? = nil
+        group : String? = nil
+        mode : Int32? = nil
+        count : UInt64? = nil
+
+        lines_read = 0_u64
+        while line = io.gets
+          break if line == "# End of header"
+
+          next unless line.starts_with?("#:")
+
+          line[2..].split(',').map(&.split('=')).each do |(k, v)|
+            case k
+            when "version"
+              version = v
+            when "file"
+              file = v
+            when "uid"
+              uid = v
+            when "user"
+              user = v
+            when "gid"
+              gid = v
+            when "group"
+              group = v
+            when "mode"
+              mode = v.to_i32(base: 8)
+            end
+          end
+        end
+
+        count = read_count(io) unless ignore_count
+
+        AsciiMetaData.new(version: version, file: file, uid: uid, user: user, gid: gid, group: group, mode: mode, count: count)
+      end
+
+      private def self.read_count(io : IO) : UInt64?
+        count : UInt64?
+        end_of_header_pos : Int32 | Int64 | Nil
+
+        begin
+          end_of_header_pos = io.pos
+        rescue
+          # ignore, this io does not support pos
+        end
+
+        return if end_of_header_pos.nil?
+
+        while line = io.gets
+          next unless line.starts_with?("#:count")
+          count = line.split('=')[1].to_u64
+        end
+        io.pos = end_of_header_pos.not_nil!
+
+        count
+      end
+    end
+
+    # Iterates over lines, joining wrapped data lines.
+    struct AsciiLineIterator(I)
+      include Iterator(String)
+
+      # Comment lines start with '#'
+      private COMMENT_BYTE = 35
+
+      def initialize(@io : I)
+      end
+
+      def next
+        while line = @io.gets
+          next if line.not_nil!.each_byte.first == COMMENT_BYTE
+
+          data = String.build do |str|
+            str << line
+
+            while !next_is_comment?
+              str << @io.gets
+            end
+          end
+
+          break data
+        end || stop
+      end
+
+      private def next_is_comment?
+        next_byte = @io.read_byte
+        return false if next_byte.nil?
+
+        @io.seek(-1, IO::Seek::Current)
+        next_byte == COMMENT_BYTE
+      end
+    end
+
+    # Iterates over data and returns decoded key/value pairs.
+    struct AsciiDataIterator(I)
+      include Iterator({String, String?})
+      include IteratorWrapper
+
+      def initialize(@io : I)
+        @iterator = AsciiLineIterator(I).new(@io)
+      end
+
+      def next
+        if (k = wrapped_next).is_a?(Iterator::Stop)
+          return k
+        else
+          k = Base64.decode_string(k)
+        end
+
+        if (v = wrapped_next).is_a?(Iterator::Stop)
+          v = nil
+        else
+          v = Base64.decode_string(v)
+        end
+
+        {k, v}
+      end
+    end
+  end
+end


### PR DESCRIPTION
- reads header meta data
- skips the `count` footer meta data by default
- ignores data lines `len` meta data